### PR TITLE
Define base font size on body

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,10 +24,20 @@
 /* ===== BODY STYLES ===== */
 body {
     font-family: 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', 'Meiryo', sans-serif;
+    font-size: 16px;
     line-height: 1.6;
     color: var(--text-primary);
     margin: 0;
     padding: 0;
+}
+
+/* Ensure text elements inherit body font size */
+p,
+li,
+blockquote,
+dd,
+dt {
+    font-size: inherit;
 }
 strong {
     font-weight: normal;


### PR DESCRIPTION
## Summary
- specify body font-size so text elements have a consistent base size
- make p and li inherit the base font size

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68491b490d4483319579bca761af1946